### PR TITLE
Add toggle-dock-animation raycast script

### DIFF
--- a/raycast/toggle-dock-animation.sh
+++ b/raycast/toggle-dock-animation.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Toggle Dock Animation
+# @raycast.mode compact
+
+# Optional parameters:
+# @raycast.icon 🚀
+# @raycast.packageName JOYCO Developer Tools
+
+current=$(defaults read com.apple.dock autohide-time-modifier 2>/dev/null)
+
+if [ "$current" = "0" ]; then
+  defaults delete com.apple.dock autohide-time-modifier 2>/dev/null
+  defaults delete com.apple.dock autohide-delay 2>/dev/null
+  echo "Dock animation: ON"
+else
+  defaults write com.apple.dock autohide-time-modifier -float 0
+  defaults write com.apple.dock autohide-delay -float 0
+  echo "Dock animation: OFF"
+fi
+
+killall Dock


### PR DESCRIPTION
## Summary
- Adds `raycast/toggle-dock-animation.sh` that toggles the macOS Dock show/hide animation on/off
- Uses `defaults write com.apple.dock autohide-time-modifier` and `autohide-delay`, restarts the Dock

## Test plan
- [ ] Run from Raycast, verify Dock hides/shows instantly
- [ ] Run again, verify animation returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)